### PR TITLE
2874: readd menu toggle (that I broke somehow along the way)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+- [PR-30](https://github.com/itk-dev/ai-screening/pull/30)
+  Tailwind classes to make the menu appear on large screens and be toggleable on small screens
 - [PR-28](https://github.com/itk-dev/ai-screening/pull/28)
   Add patch for missing menu active trail on views
   Add menu item for projects in view instead of as content

--- a/web/themes/custom/itkdev/itkdev_base_theme/templates/components/site-navigation.html.twig
+++ b/web/themes/custom/itkdev/itkdev_base_theme/templates/components/site-navigation.html.twig
@@ -15,6 +15,6 @@
       {{ page.global_navigation_menu_secondary_brand }}
     </div>
   </div>
-  <div :class="sidebarToggle ? 'block' : 'hidden'" class="bg-primary opacity-50 w-100 h-100 absolute top-0 bottom-0 left-0 right-0 z-10">
+  <div :class="sidebarToggle ? 'block' : 'hidden'" class="bg-primary opacity-0 w-100 h-100 absolute top-0 bottom-0 left-0 right-0 z-10">
   </div>
 </aside>

--- a/web/themes/custom/itkdev/itkdev_project_theme/templates/components/nav-button.html.twig
+++ b/web/themes/custom/itkdev/itkdev_project_theme/templates/components/nav-button.html.twig
@@ -1,3 +1,3 @@
-<div class="lg:hidden nav-button">
-  <button @click.stop="sidebarToggle = !sidebarToggle" class="border border-primary bg-secondary text-secondary  rounded px-3 py-2"><i class="fa-solid fa-bars"></i><span class="sr-only">{{ 'Open navigation menu'|t }}</span></button>
+<div class="nav-button">
+  <button @click.stop="sidebarToggle = !sidebarToggle" class="border border-primary bg-secondary text-secondary lg:hidden rounded px-3 py-2"><i class="fa-solid fa-bars"></i><span class="sr-only">{{ 'Open navigation menu'|t }}</span></button>
 </div>

--- a/web/themes/custom/itkdev/itkdev_project_theme/templates/page.html.twig
+++ b/web/themes/custom/itkdev/itkdev_project_theme/templates/page.html.twig
@@ -50,7 +50,7 @@
   <main role="main" class="">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
     <div class="flex h-screen overflow-hidden">
-      <aside class="absolute w-72 h-screen left-0 top-0 z-20 flex flex-col overflow-y-hidden bg-zinc-800 duration-300 ease-linear lg:static lg:translate-x-0 -translate-x-full border-r border-slate-100">
+      <aside :class="sidebarToggle ? 'translate-x-0' : '-translate-x-full'" class="absolute w-72 h-screen left-0 top-0 z-20 flex flex-col overflow-y-hidden bg-zinc-800 duration-300 ease-linear lg:static lg:translate-x-0 -translate-x-full border-r border-slate-100" @click.outside="sidebarToggle = false">
         {{ page.navigation }}
       </aside>
       <div class="relative flex flex-1 flex-col overflow-y-auto overflow-x-hidden">


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showTicket/2874

#### Description

- Tailwind class gymnastics to make the menu:
- Always appear on large screens
- be toggleable on smaller screens...

#### Screenshot of the result

<img width="1178" alt="Screenshot 2024-11-08 at 13 54 33" src="https://github.com/user-attachments/assets/760e6256-cb1b-4c2c-bd94-4c10d4de6544">


<img width="1068" alt="Screenshot 2024-11-08 at 13 54 47" src="https://github.com/user-attachments/assets/92e94583-00a3-40cf-b4d6-30e25155fd3c">


