### PR TITLE
Added Drupal update check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -197,3 +197,46 @@ jobs:
       - name: Run module tests
         run: |
           docker compose exec --user root phpfpm bash -c 'cd web && ../vendor/bin/phpunit --configuration ../phpunit.xml modules/custom'
+
+  update-site:
+    name: Check that site can be updated
+    runs-on: ubuntu-latest
+    steps:
+      # Install site from our base ref
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: setup-docker-and-composer
+        run: |
+          docker network create frontend
+          docker compose pull
+          docker compose up --detach
+
+          # Important: Use --no-interaction to make https://getcomposer.org/doc/06-config.md#discard-changes have effect.
+          docker compose exec --user root phpfpm composer install --no-interaction
+
+      - name: Install site
+        run: |
+          # Install the site from config
+          docker compose exec --user root phpfpm vendor/bin/drush site:install --existing-config --yes
+
+      - name: Clean up root stuff
+        run: |
+          sudo chown -Rv $USER:$USER vendor/ web/ || true
+          sudo chmod -Rv a+w web/sites/default || true
+
+      # Install site with our current ref
+      - uses: actions/checkout@v4
+
+      - name: setup-docker-and-composer
+        run: |
+          docker compose pull
+          docker compose up --detach
+
+          # Important: Use --no-interaction to make https://getcomposer.org/doc/06-config.md#discard-changes have effect.
+          docker compose exec --user root phpfpm composer install --no-interaction
+
+      - name: Update site
+        run: |
+          docker compose exec --user root phpfpm vendor/bin/drush deploy --yes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+- [PR-34](https://github.com/itk-dev/ai-screening/pull/34)
+  Added Drupal update check
 - [PR-33](https://github.com/itk-dev/ai-screening/pull/33)
   OIDC tweaks
 - [PR-32](https://github.com/itk-dev/ai-screening/pull/32)


### PR DESCRIPTION
Adds a check to check that site can be updated (after a clean installation using the base ref).

We're pragmatic and still allow breaking changes, but in the future we have to make sure that we have a clean update path for our projects.

Example on breaking the update path:

``` shell
git checkout 9d368a5724bd2c94ccb8c5703bb3d8f558a70a3f
task site-install --yes

git checkout 6a563c55dcbe1397487aea08764450ef8e67784e
task site-update --yes
```
