### PR TITLE
3065: add styling to user img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+- [PR-59](https://github.com/itk-dev/ai-screening/pull/59)
+  Add tailwind classes to style user image
 - [PR-58](https://github.com/itk-dev/ai-screening/pull/58)
   Added theming for messages
 - [PR-53](https://github.com/itk-dev/ai-screening/pull/53)

--- a/web/themes/custom/itkdev/itkdev_project_theme/templates/components/user-menu.html.twig
+++ b/web/themes/custom/itkdev/itkdev_project_theme/templates/components/user-menu.html.twig
@@ -16,7 +16,7 @@
         <span class="h-12 w-12 rounded-full bg-secondary overflow-hidden">
           {% set imageUrl = drupal_field('field_image', 'user', user.id, {type: 'image_url', settings: {image_style: 'thumbnail'}}) %}
           {% set alt = drupal_field('field_image', 'user', user.id)[0]['#item'].alt %}
-            <img src="{{ imageUrl[0] }}" alt="{{ alt }}">
+            <img class="object-cover h-12" src="{{ imageUrl[0] }}" alt="{{ alt }}">
         </span>
 
         <i class="fa-solid fa-angle-down" :class="dropdownOpen && 'rotate-180'"></i>


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3065

#### Description

Add tailwind classes to style user image

#### Screenshot of the result

**FROM**

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/97eda834-6d34-4b7e-aa27-28b92f3d6db2">

**TO**

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/ed145e53-eb5c-4089-b4c1-45651526a244">

