### PR TITLE
Added Yes/No stop webform element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+- [PR-82](https://github.com/itk-dev/ai-screening/pull/82)
+  Added Yes/no stop webform element
 - [PR-80](https://github.com/itk-dev/ai-screening/pull/80)
   - Added static select webform element
 - [PR-77](https://github.com/itk-dev/ai-screening/pull/77)

--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -177,6 +177,7 @@ element:
     number: number
     password: password
     password_confirm: password_confirm
+    processed_text: processed_text
     radios: radios
     range: range
     search: search
@@ -184,6 +185,7 @@ element:
     table: table
     tableselect: tableselect
     tel: tel
+    text_format: text_format
     textarea: textarea
     textfield: textfield
     url: url
@@ -213,7 +215,6 @@ element:
     webform_likert: webform_likert
     webform_link: webform_link
     webform_mapping: webform_mapping
-    webform_markup: webform_markup
     webform_message: webform_message
     webform_more: webform_more
     webform_name: webform_name

--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -177,7 +177,6 @@ element:
     number: number
     password: password
     password_confirm: password_confirm
-    processed_text: processed_text
     radios: radios
     range: range
     search: search
@@ -185,7 +184,6 @@ element:
     table: table
     tableselect: tableselect
     tel: tel
-    text_format: text_format
     textarea: textarea
     textfield: textfield
     url: url

--- a/config/sync/webform.webform.jura.yml
+++ b/config/sync/webform.webform.jura.yml
@@ -1,0 +1,213 @@
+uuid: 2c1b3580-0e9b-454f-8ce5-c76fee5d58ca
+langcode: da
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: jura
+title: Jura
+description: ''
+categories: {  }
+elements: |-
+  q:
+    '#type': ai_screening_yes_no_stop
+    '#title': 'An important question'
+    '#description': '<p>Do you know stuff?</p>'
+    '#text_question': "<p>Do you really know what you're doing?</p>"
+    '#text_yes': '<p>Yes, sir!</p>'
+    '#text_no': '<p>No!</p>'
+    '#stop_value': '1'
+    '#text_stop': '<p><strong>STOP!</strong></p>'
+    '#text_question_format': simple_editor
+    '#text_yes_format': simple_editor
+    '#text_no_format': simple_editor
+    '#text_stop_format': simple_editor
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/config/sync/webform.webform.jura.yml
+++ b/config/sync/webform.webform.jura.yml
@@ -13,7 +13,7 @@ title: Jura
 description: ''
 categories: {  }
 elements: |-
-  q:
+  q0:
     '#type': ai_screening_yes_no_stop
     '#title': 'An important question'
     '#description': '<p>Do you know stuff?</p>'
@@ -22,10 +22,46 @@ elements: |-
     '#text_no': '<p>No!</p>'
     '#stop_value': '1'
     '#text_stop': '<p><strong>STOP!</strong></p>'
+  q1:
+    '#type': ai_screening_yes_no_stop
+    '#title': 'An important question'
+    '#description': '<p>Do you know stuff?</p>'
+    '#text_question': "<p>Do you really know what you're doing?</p>"
+    '#text_yes': '<p>Yes, sir!</p>'
+    '#text_no': '<p>No!</p>'
+    '#stop_value': '0'
+    '#text_stop': '<p><strong>STOP!</strong></p>'
     '#text_question_format': simple_editor
     '#text_yes_format': simple_editor
     '#text_no_format': simple_editor
     '#text_stop_format': simple_editor
+  q2:
+    '#type': ai_screening_yes_no_stop
+    '#title': 'An important question'
+    '#description': '<p>Do you know stuff?</p>'
+    '#text_question': "<p>Do you really know what you're doing?</p>"
+    '#text_yes': '<p>Yes, sir!</p>'
+    '#text_no': '<p>No!</p>'
+    '#stop_value': '0'
+    '#text_question_format': simple_editor
+    '#text_yes_format': simple_editor
+    '#text_no_format': simple_editor
+    '#text_stop_format': simple_editor
+  q3:
+    '#type': ai_screening_yes_no_stop
+    '#title': 'An important question'
+    '#description': '<p>Do you know stuff?</p>'
+    '#text_question': "<p>Do you really know what you're doing?</p>"
+    '#text_yes': '<p>Yes, sir!</p>'
+    '#text_no': '<p>No!</p>'
+    '#stop_value': '0'
+    '#text_question_format': simple_editor
+    '#text_yes_format': simple_editor
+    '#text_no_format': simple_editor
+    '#text_stop_format': simple_editor
+  markup:
+    '#type': webform_markup
+    '#markup': "<p>That's all Folks!</p>"
 css: ''
 javascript: ''
 settings:

--- a/web/modules/custom/ai_screening/src/Helper/ThemeHelper.php
+++ b/web/modules/custom/ai_screening/src/Helper/ThemeHelper.php
@@ -51,12 +51,13 @@ final class ThemeHelper extends AbstractHelper implements EventSubscriberInterfa
     if ($hook === 'form' & !empty($variables['element']['#id'])) {
       $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#id']);
     }
-    if ($hook === 'select' & !empty($variables['element']['#id'])) {
-      if ('ai_screening_static_select' === $variables['element']['#type']) {
+    if ($hook === 'select') {
+      if (isset($variables['element']['#id'])) {
+        $suggestions[] = 'select__' . str_replace('-', '_', $variables['element']['#id']);
+      }
+      if (isset($variables['element']['#type'])) {
         $suggestions[] = 'select__' . str_replace('-', '_', $variables['element']['#type']);
       }
-
-      $suggestions[] = 'select__' . str_replace('-', '_', $variables['element']['#id']);
     }
   }
 

--- a/web/modules/custom/ai_screening_project_track/src/Element/YesNoStop.php
+++ b/web/modules/custom/ai_screening_project_track/src/Element/YesNoStop.php
@@ -8,6 +8,7 @@ use Drupal\Core\Render\Element\CompositeFormElementTrait;
 use Drupal\Core\Render\Element\Select;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\ai_screening_project_track\Plugin\WebformElement\YesNoStop as WebformYesNoStopElement;
+use Drupal\webform\Element\WebformHtmlEditor;
 
 /**
  * Yes/no stop element.
@@ -69,11 +70,7 @@ final class YesNoStop extends Select {
       $element[$elementName] = [
         '#type' => 'container',
         '#attributes' => ['class' => $classNames],
-        'message' => [
-          '#type' => 'processed_text',
-          '#text' => $element[$elementKey] ?? '',
-          '#format' => $element[WebformYesNoStopElement::getFormatKey($elementKey)] ?? WebformYesNoStopElement::getTextFormat(),
-        ],
+        'message' => WebformHtmlEditor::checkMarkup($element[$elementKey] ?? '', ['tidy' => FALSE]),
         '#states' => $states(value: $value),
       ];
     }

--- a/web/modules/custom/ai_screening_project_track/src/Element/YesNoStop.php
+++ b/web/modules/custom/ai_screening_project_track/src/Element/YesNoStop.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\ai_screening_project_track\Element;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element\CompositeFormElementTrait;
+use Drupal\Core\Render\Element\Select;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ai_screening_project_track\Plugin\WebformElement\YesNoStop as WebformYesNoStopElement;
+
+/**
+ * Yes/no stop element.
+ *
+ * @FormElement("ai_screening_yes_no_stop")
+ */
+final class YesNoStop extends Select {
+  use CompositeFormElementTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $info = parent::getInfo();
+
+    // Our process function must run before other functions.
+    array_unshift($info['#process'], [static::class, 'processYesNoStop']);
+
+    return $info;
+  }
+
+  /**
+   * Process callback.
+   */
+  public static function processYesNoStop(array &$element, FormStateInterface $form_state, array &$complete_form): array {
+    $element['#options'] = [
+      WebformYesNoStopElement::VALUE_YES => new TranslatableMarkup('Yes'),
+      WebformYesNoStopElement::VALUE_NO => new TranslatableMarkup('No'),
+    ];
+    $element['#empty_option'] = (string) (new TranslatableMarkup('- Select -'));
+    $element['#required'] = TRUE;
+
+    $states = static fn(?string $value = NULL): array => NULL !== $value
+      ? [
+        'visible' => [
+          sprintf(':input[name="%s"]', $element['#webform_key']) => [
+            'value' => $value,
+          ],
+        ],
+      ]
+      : [];
+
+    $textElements = [
+      [WebformYesNoStopElement::ELEMENT_TEXT_QUESTION, NULL],
+      [WebformYesNoStopElement::ELEMENT_TEXT_YES, WebformYesNoStopElement::VALUE_YES],
+      [WebformYesNoStopElement::ELEMENT_TEXT_NO, WebformYesNoStopElement::VALUE_NO],
+    ];
+    $stopValue = $element['#stop_value'] ?? NULL;
+    if (NULL !== $stopValue) {
+      $textElements[] = [WebformYesNoStopElement::ELEMENT_TEXT_STOP, $stopValue];
+    }
+
+    foreach ($textElements as [$elementName, $value]) {
+      $classNames = [Html::getClass(WebformYesNoStopElement::ID . '--' . $elementName)];
+      if (NULL !== $value && $value === $stopValue) {
+        $classNames[] = Html::getClass(WebformYesNoStopElement::ID . '--is-stop-value');
+      }
+      $elementKey = '#' . $elementName;
+      $element[$elementName] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => $classNames],
+        'message' => [
+          '#type' => 'processed_text',
+          '#text' => $element[$elementKey] ?? '',
+          '#format' => $element[WebformYesNoStopElement::getFormatKey($elementKey)] ?? WebformYesNoStopElement::getTextFormat(),
+        ],
+        '#states' => $states(value: $value),
+      ];
+    }
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/ai_screening_project_track/src/Helper/ProjectTrackToolHelper.php
+++ b/web/modules/custom/ai_screening_project_track/src/Helper/ProjectTrackToolHelper.php
@@ -372,7 +372,9 @@ final class ProjectTrackToolHelper extends AbstractHelper implements EventSubscr
       ->condition('tool_id', $submission->id(), '=')
       ->execute();
 
-    return $this->projectTrackToolStorage->load(reset($ids)) ?: NULL;
+    $id = reset($ids) ?: NULL;
+
+    return $id !== NULL ? $this->projectTrackToolStorage->load($id) : NULL;
   }
 
 }

--- a/web/modules/custom/ai_screening_project_track/src/Plugin/WebformElement/YesNoStop.php
+++ b/web/modules/custom/ai_screening_project_track/src/Plugin/WebformElement/YesNoStop.php
@@ -6,7 +6,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\webform\Plugin\WebformElement\OptionsBase;
-use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Yes/no stop element.
@@ -52,7 +51,6 @@ final class YesNoStop extends OptionsBase {
     foreach (static::TEXT_ELEMENTS as $name) {
       $defaultProperties += [
         $name => '',
-        self::getFormatKey($name) => '',
       ];
     }
 
@@ -71,12 +69,9 @@ final class YesNoStop extends OptionsBase {
       $form['options'][$key]['#access'] = FALSE;
     }
 
-    $format = static::getTextFormat();
-    $addTextElement = static function &(string $key, string|TranslatableMarkup $title, string|TranslatableMarkup|null $description = NULL) use (&$form, $format): array {
+    $addTextElement = static function &(string $key, string|TranslatableMarkup $title, string|TranslatableMarkup|null $description = NULL) use (&$form): array {
       $form['options'][$key] = [
-        '#type' => 'text_format',
-        '#format' => $format,
-        '#allowed_formats' => [$format],
+        '#type' => 'webform_html_editor',
         '#title' => $title,
         '#description' => $description,
       ];
@@ -125,52 +120,6 @@ final class YesNoStop extends OptionsBase {
     ];
 
     return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   *
-   * @see ProcessedText::setConfigurationFormDefaultValue()
-   */
-  protected function setConfigurationFormDefaultValue(array &$form, array &$element_properties, array &$property_element, $property_name) {
-    if (in_array($property_name, static::TEXT_ELEMENTS)) {
-      $formatKey = static::getFormatKey($property_name);
-      if (isset($element_properties[$formatKey])) {
-        $property_element['#format'] = $element_properties[$formatKey];
-        unset($element_properties[$formatKey]);
-      }
-    }
-
-    parent::setConfigurationFormDefaultValue($form, $element_properties, $property_element, $property_name);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getConfigurationFormProperty(array &$properties, $property_name, $property_value, array $element) {
-    if (in_array($property_name, static::TEXT_ELEMENTS)) {
-      if (isset($property_value['value'], $property_value['format'])) {
-        $properties[$property_name] = $property_value['value'] ?? NULL;
-        $properties[static::getFormatKey($property_name)] = $property_value['format'] ?? NULL;
-      }
-    }
-    else {
-      parent::getConfigurationFormProperty($properties, $property_name, $property_value, $element);
-    }
-  }
-
-  /**
-   * Get text format.
-   */
-  public static function getTextFormat(): string {
-    return 'simple_editor';
-  }
-
-  /**
-   * Get (text) format key.
-   */
-  public static function getFormatKey(string $key): string {
-    return $key . '_format';
   }
 
 }

--- a/web/modules/custom/ai_screening_project_track/src/Plugin/WebformElement/YesNoStop.php
+++ b/web/modules/custom/ai_screening_project_track/src/Plugin/WebformElement/YesNoStop.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Drupal\ai_screening_project_track\Plugin\WebformElement;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\webform\Plugin\WebformElement\OptionsBase;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * Yes/no stop element.
+ *
+ * Uses bits and pieces from
+ * \Drupal\webform\Plugin\WebformElement\ProcessedText.
+ *
+ * @WebformElement(
+ *   id = "ai_screening_yes_no_stop",
+ *   label = @Translation("Yes/no stop"),
+ *   description = @Translation("Yes/no question."),
+ *   category = @Translation("AI Screening"),
+ * )
+ */
+final class YesNoStop extends OptionsBase {
+  const string ID = 'ai_screening_yes_no_stop';
+
+  const string ELEMENT_TEXT_QUESTION = 'text_question';
+  const string ELEMENT_TEXT_YES = 'text_yes';
+  const string ELEMENT_TEXT_NO = 'text_no';
+  const string ELEMENT_TEXT_STOP = 'text_stop';
+  const string ELEMENT_STOP_VALUE = 'stop_value';
+
+  private const array TEXT_ELEMENTS = [
+    self::ELEMENT_TEXT_QUESTION,
+    self::ELEMENT_TEXT_YES,
+    self::ELEMENT_TEXT_NO,
+    self::ELEMENT_TEXT_STOP,
+  ];
+
+  // Note: We use strings for numeric values to make comparisons easier in
+  // the code.
+  const string VALUE_YES = '1';
+  const string VALUE_NO = '0';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineDefaultProperties(): array {
+    $defaultProperties = [
+      self::ELEMENT_STOP_VALUE => '',
+    ];
+    foreach (static::TEXT_ELEMENTS as $name) {
+      $defaultProperties += [
+        $name => '',
+        self::getFormatKey($name) => '',
+      ];
+    }
+
+    return $defaultProperties + parent::defineDefaultProperties();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public function form(array $form, FormStateInterface $form_state): array {
+    $form = parent::form($form, $form_state);
+
+    // Hide all options options.
+    foreach (Element::children($form['options']) as $key) {
+      $form['options'][$key]['#access'] = FALSE;
+    }
+
+    $format = static::getTextFormat();
+    $addTextElement = static function &(string $key, string|TranslatableMarkup $title, string|TranslatableMarkup|null $description = NULL) use (&$form, $format): array {
+      $form['options'][$key] = [
+        '#type' => 'text_format',
+        '#format' => $format,
+        '#allowed_formats' => [$format],
+        '#title' => $title,
+        '#description' => $description,
+      ];
+
+      return $form['options'][$key];
+    };
+
+    // Add our options.
+    $addTextElement(
+      self::ELEMENT_TEXT_QUESTION,
+      $this->t('Question'),
+    );
+    $addTextElement(
+      self::ELEMENT_TEXT_YES,
+      $this->t('Yes text'),
+      $this->t('The text to display when answering "yes".'),
+    );
+    $addTextElement(
+      self::ELEMENT_TEXT_NO,
+      $this->t('No text'),
+      $this->t('The text to display when answering "no".'),
+    );
+
+    $form['options'][self::ELEMENT_STOP_VALUE] = [
+      '#type' => 'select',
+      '#options' => [
+        self::VALUE_YES => $this->t('Yes'),
+        self::VALUE_NO => $this->t('No'),
+      ],
+      '#empty_value' => '',
+      '#title' => $this->t('Stop value'),
+      '#description' => $this->t('The answer to trigger a "stop".'),
+    ];
+
+    $element = &$addTextElement(
+      self::ELEMENT_TEXT_STOP,
+      $this->t('Stop text'),
+      $this->t('The text to display when answering with the "stop" value.'),
+    );
+    $element['#states'] = [
+      'visible' => [
+        sprintf(':input[name="properties[%s]"]', self::ELEMENT_STOP_VALUE) => [
+          'empty' => FALSE,
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @see ProcessedText::setConfigurationFormDefaultValue()
+   */
+  protected function setConfigurationFormDefaultValue(array &$form, array &$element_properties, array &$property_element, $property_name) {
+    if (in_array($property_name, static::TEXT_ELEMENTS)) {
+      $formatKey = static::getFormatKey($property_name);
+      if (isset($element_properties[$formatKey])) {
+        $property_element['#format'] = $element_properties[$formatKey];
+        unset($element_properties[$formatKey]);
+      }
+    }
+
+    parent::setConfigurationFormDefaultValue($form, $element_properties, $property_element, $property_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getConfigurationFormProperty(array &$properties, $property_name, $property_value, array $element) {
+    if (in_array($property_name, static::TEXT_ELEMENTS)) {
+      if (isset($property_value['value'], $property_value['format'])) {
+        $properties[$property_name] = $property_value['value'] ?? NULL;
+        $properties[static::getFormatKey($property_name)] = $property_value['format'] ?? NULL;
+      }
+    }
+    else {
+      parent::getConfigurationFormProperty($properties, $property_name, $property_value, $element);
+    }
+  }
+
+  /**
+   * Get text format.
+   */
+  public static function getTextFormat(): string {
+    return 'simple_editor';
+  }
+
+  /**
+   * Get (text) format key.
+   */
+  public static function getFormatKey(string $key): string {
+    return $key . '_format';
+  }
+
+}

--- a/web/themes/custom/itkdev/itkdev_project_theme/templates/form/form-element--webform-ai-screening-yes-no-stop.html.twig
+++ b/web/themes/custom/itkdev/itkdev_project_theme/templates/form/form-element--webform-ai-screening-yes-no-stop.html.twig
@@ -1,0 +1,68 @@
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'js-form-type-' ~ type|clean_class,
+    'form-item-' ~ name|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+    'mb-3 md:mb-5',
+    type == 'radio' ? 'flex items-center gap-3 cursor-pointer',
+    type == 'checkbox' ? 'flex items-center gap-3',
+  ]
+%}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% if label_display in ['before', 'invisible'] %}
+    {{ label }}
+  {% endif %}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description.content and (description_display == 'before' or type == 'radio') %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+
+  {% if element.text_question %}
+    {{ element.text_question }}
+  {% endif %}
+
+  {{ children }}
+
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if label_display == 'after' %}
+    {{ label }}
+  {% endif %}
+  {% if errors %}
+    <div class="form-item--error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+
+  {% if element.text_yes %}
+    {{ element.text_yes }}
+  {% endif %}
+  {% if element.text_no %}
+    {{ element.text_no }}
+  {% endif %}
+  {% if element.text_stop %}
+    {{ element.text_stop }}
+  {% endif %}
+
+</div>


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=3656#/tickets/showTicket/3656>

#### Description

Adds Yes/no stop webform element. Enables “webform_markup” element to make it possible to add static text on a form.

Still missing:

* [ ] Rendering on submission result page
* [ ] Styling

#### Screenshot of the result

Editing a yes/no/stop element:

![Screen Shot 2025-01-23 at 11 07 44](https://github.com/user-attachments/assets/eecdd174-cfed-46cd-94ce-7b027c745284)

Result on form (with 4 different yes/no/stop elements):

![Screen Shot 2025-01-23 at 10 14 21](https://github.com/user-attachments/assets/c9b6454e-4fd1-483d-ab49-5158f0ba7fb0)

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
